### PR TITLE
Use .ruby_version for Gemfile and github actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
   test:
     docker:
       # specify the version you desire here
-      - image: cimg/ruby:3.0-browsers
+      - image: cimg/ruby:3.0.0-browsers
         environment:
           BUNDLE_GEMFILE: Gemfile
           BUNDLE_PATH: vendor/bundle
@@ -158,7 +158,7 @@ jobs:
           path: ./tmp/screenshots
   lint:
     docker:
-      - image: cimg/ruby:3.0-node
+      - image: cimg/ruby:3.0.0-node
         environment:
           DISABLE_SPRING: 1
           BUNDLE_GEMFILE: Gemfile.tools
@@ -198,7 +198,7 @@ jobs:
 
   upgrade_tools:
     docker:
-      - image: cimg/ruby:3.0-node
+      - image: cimg/ruby:3.0.0-node
         environment:
           DISABLE_SPRING: 1
           BUNDLE_GEMFILE: Gemfile.tools

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
           bundler-cache: true
 
       - name: Use Node.js

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '3.0.0'
+ruby RUBY_VERSION
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'rails', '~> 6.1.3', '>= 6.1.3.1'


### PR DESCRIPTION
There are failed CI checks failed because uses different versions of Ruby. Specified 3.0.0 everywhere